### PR TITLE
Migration to Ulauncher Extension API v1 -> v2

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,14 +15,14 @@ def scan_chrome_folder(chrome_config_folder):
     with open(os.path.join(chrome_config_folder, 'Local State')) as f:
         local_state = json.load(f)
         cache = local_state['profile']['info_cache']
-        for folder, profile_data in cache.iteritems():
+        for folder, profile_data in cache.items():
             profiles[folder] = {
                 'name': profile_data['name'],
                 'email': profile_data['user_name']
             }
 
     # Leave out every past profile which doesn't exist anymore
-    for folder in profiles.keys():
+    for folder in list(profiles.keys()):
         try:
             os.listdir(os.path.join(chrome_config_folder, folder))
         except:
@@ -47,7 +47,7 @@ class KeywordQueryEventListener(EventListener):
         query = event.get_argument()
         if query:
             query = query.strip().lower()
-            for folder in profiles.keys():
+            for folder in list(profiles.keys()):
                 name = profiles[folder]['name'].lower()
                 if query not in name:
                     profiles.pop(folder)

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": "2",
-  "api_version": "1",
+  "required_api_version": "^2.0.0",
   "name": "Chrome Profiles",
   "description": "Provides an easy way to launch chrome with different user profiles",
   "developer_name": "Alessandro Racheli <alessandroracheli@gmail.com>",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+[
+  { "required_api_version": "^1.0.0", "commit": "ulauncher-v1" },
+  { "required_api_version": "^2.0.0", "commit": "master" }
+]


### PR DESCRIPTION
For further details see the [official documentation](http://docs.ulauncher.io/en/latest/extensions/migration.html#migrate-from-api-v1-to-v2-0-0).